### PR TITLE
Implement V0 and V1 decompositions

### DIFF
--- a/qbench/fourier.py
+++ b/qbench/fourier.py
@@ -1,3 +1,4 @@
+import numpy as np
 from braket import circuits
 
 
@@ -31,3 +32,35 @@ def global_phase_circuit(phi: float, target: int):
     :return: A circuit comprising gates shifting global phase of the target qubit.
     """
     return circuits.Circuit().phaseshift(target, 2 * phi).rz(target, -2 * phi)
+
+
+def v0_circuit(phi: float, target: int, preserve_global_phase=True):
+    """Circuit implementing V0 operation on given qubit.
+
+    :param phi: rotation angle.
+    :param target: qubit V0 should be applied to
+    :param preserve_global_phase: whether the decomposition should preserve global phase.
+     This should matter only if V0 is used to construct a controlled gate, and is irrelevant
+     otherwise. To be on the safe side, the default is `True`. Note that including global phase
+     adds two more gates to the circuit.
+    """
+    circuit = (
+        global_phase_circuit(np.pi / 4, target) if preserve_global_phase else circuits.Circuit()
+    )
+    return circuit.ry(target, (phi + np.pi) / 2).rz(target, -np.pi / 2)
+
+
+def v1_circuit(phi: float, target: int, preserve_global_phase=True):
+    """Circuit implementing V0 operation on given qubit.
+
+    :param phi: rotation angle.
+    :param target: qubit V1 should be applied to
+    :param preserve_global_phase: whether the decomposition should preserve global phase.
+     This should matter only if V1 is used to construct a controlled gate, and is irrelevant
+     otherwise. To be on the safe side, the default is `True`. Note that including global phase
+     adds two more gates to the circuit.
+    """
+    circuit = (
+        global_phase_circuit(3 * np.pi / 4, target) if preserve_global_phase else circuits.Circuit()
+    )
+    return circuit.rx(target, np.pi).ry(target, (phi + np.pi) / 2).rz(target, -np.pi / 2)

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -6,7 +6,37 @@ from qbench.fourier import (
     global_phase_circuit,
     measurement_circuit,
     state_preparation_circuit,
+    v0_circuit,
+    v1_circuit,
 )
+
+
+def _v0_ref(phi):
+    """Explicit formula for V0.
+
+    This function is used for comparison with V0 decomposed into gates available in Amazon braket.
+    """
+    phi_adjusted = (np.pi - phi) / 4
+    return np.array(
+        [
+            [1j * np.sin(phi_adjusted), -1j * np.cos(phi_adjusted)],
+            [np.cos(phi_adjusted), np.sin(phi_adjusted)],
+        ]
+    )
+
+
+def _v1_ref(phi):
+    """Explicit formula for V1.
+
+    This function is used for comparison with V1 decomposed into gates available in Amazon braket.
+    """
+    phi_adjusted = (np.pi - phi) / 4
+    return np.array(
+        [
+            [-1j * np.cos(phi_adjusted), 1j * np.sin(phi_adjusted)],
+            [np.sin(phi_adjusted), np.cos(phi_adjusted)],
+        ]
+    )
 
 
 def test_initial_state_prepared_from_ket_zeros_is_maximally_entangled():
@@ -30,3 +60,38 @@ def test_decomposition_of_global_phase_expected_correct_unitary(phi):
     actual = global_phase_circuit(phi, 0).as_unitary()
 
     np.testing.assert_allclose(expected, actual)
+
+
+@pytest.mark.parametrize("phi", np.linspace(0, 2 * np.pi, 100))
+def test_decomposed_v0_is_equal_to_the_original_one_if_global_phase_is_preserved(phi):
+    actual = v0_circuit(phi, 0, preserve_global_phase=True).as_unitary()
+    expected = _v0_ref(phi)
+
+    np.testing.assert_allclose(expected, actual, atol=1e-10)
+
+
+@pytest.mark.parametrize("phi", np.linspace(0, 2 * np.pi, 100))
+def test_decomposed_v1_is_equal_to_the_original_one_if_global_phase_is_preserved(phi):
+    actual = v1_circuit(phi, 0, preserve_global_phase=True).as_unitary()
+    expected = _v1_ref(phi)
+
+    np.testing.assert_allclose(expected, actual, atol=1e-10)
+
+
+@pytest.mark.parametrize("phi", np.linspace(0, 2 * np.pi, 100))
+def test_decomposed_v0_differs_from_the_original_one_only_by_phase(phi):
+    # Since v0 is unitary, multiplication of the form (const * v0) @ v0^dagger should be
+    # a scalar matrix, which is what this test checks.
+    expected_diag = (
+        v0_circuit(phi, 0, preserve_global_phase=False).as_unitary() @ _v0_ref(phi).conj().T
+    )
+    np.testing.assert_allclose(expected_diag, np.eye(2) * expected_diag[0, 0], atol=1e-10)
+
+
+@pytest.mark.parametrize("phi", np.linspace(0, 2 * np.pi, 100))
+def test_decomposed_v1_differs_from_the_original_one_only_by_phase(phi):
+    # See previous test for v0 for explanation of this test.
+    expected_diag = (
+        v1_circuit(phi, 0, preserve_global_phase=False).as_unitary() @ _v1_ref(phi).conj().T
+    )
+    np.testing.assert_allclose(expected_diag, np.eye(2) * expected_diag[0, 0], atol=1e-10)


### PR DESCRIPTION
This implements decompositions of V0 and V1 (from our note) into gates native to braket. Both decompositions have a version that doesn't preserve the global phase, which saves two gates and can be used if V0 or V1 is not used for constructing a controlled gate.