### PR TITLE
Native Rigetti implementation of V0 and V1

### DIFF
--- a/qbench/fourier.py
+++ b/qbench/fourier.py
@@ -22,19 +22,44 @@ def measurement_circuit(phi: float, target: int = 0) -> circuits.Circuit:
     return circuits.Circuit().h(target).phaseshift(target, phi).h(target)
 
 
-def v0_circuit(phi: float, target: int):
+def v0_circuit(phi: float, target: int, native_only: bool = False):
     """Circuit implementing V0 operation on given qubit.
 
     :param phi: rotation angle.
     :param target: qubit V0 should be applied to
+    :param native_only: use only gates native to current Rigetti QPUs. Use this if you
+     don't trust the compiler.
+    :return: Circuit performing V0 operation.
     """
-    return circuits.Circuit().ry(target, (phi + np.pi) / 2).rz(target, -np.pi / 2)
+    return (
+        circuits.Circuit()
+        .rx(target, np.pi / 2)
+        .rz(target, (phi + np.pi) / 2)
+        .rx(target, -np.pi / 2)
+        .rz(target, -np.pi / 2)
+        if native_only
+        else circuits.Circuit().ry(target, (phi + np.pi) / 2).rz(target, -np.pi / 2)
+    )
 
 
-def v1_circuit(phi: float, target: int):
+def v1_circuit(phi: float, target: int, native_only: bool = False):
     """Circuit implementing V0 operation on given qubit.
 
     :param phi: rotation angle.
-    :param target: qubit V1 should be applied to
+    :param target: qubit V1 should be applied to.
+    :param native_only: use only gates native to current Rigetti QPUs. Use this if you
+     don't trust the compiler.
+    :return: Circuit performing V1 operation.
     """
-    return circuits.Circuit().rx(target, np.pi).ry(target, (phi + np.pi) / 2).rz(target, -np.pi / 2)
+    return (
+        circuits.Circuit()
+        .rx(target, np.pi / 2)
+        .rz(target, (np.pi - phi) / 2)
+        .rx(target, -np.pi / 2)
+        .rz(target, np.pi / 2)
+        if native_only
+        else circuits.Circuit()
+        .rx(target, np.pi)
+        .ry(target, (phi + np.pi) / 2)
+        .rz(target, -np.pi / 2)
+    )

--- a/tests/test_fourier.py
+++ b/tests/test_fourier.py
@@ -61,17 +61,19 @@ def test_measurement_circuit_has_correct_unitary(phi):
     np.testing.assert_allclose(circuit.as_unitary(), expected_unitary, atol=1e-6)
 
 
+@pytest.mark.parametrize("native_only", [True, False])
 @pytest.mark.parametrize("phi", np.linspace(0, 2 * np.pi, 100))
-def test_decomposed_v0_is_equal_to_the_original_one(phi):
-    actual = v0_circuit(phi, 0).as_unitary()
+def test_decomposed_v0_is_equal_to_the_original_one(phi, native_only):
+    actual = v0_circuit(phi, 0, native_only=native_only).as_unitary()
     expected = _v0_ref(phi)
 
     _assert_is_equal_up_to_phase(actual, expected)
 
 
+@pytest.mark.parametrize("native_only", [True, False])
 @pytest.mark.parametrize("phi", np.linspace(0, 2 * np.pi, 100))
-def test_decomposed_v1_is_equal_to_the_original_one(phi):
-    actual = v1_circuit(phi, 0).as_unitary()
+def test_decomposed_v1_is_equal_to_the_original_one(phi, native_only):
+    actual = v1_circuit(phi, 0, native_only=native_only).as_unitary()
     expected = _v1_ref(phi)
 
     _assert_is_equal_up_to_phase(actual, expected)


### PR DESCRIPTION
This PR introduces the native implementation of V0 and V1, i.e. an implementation comprising only gates that can be physically realizable on Rigetti QPUs (see [here](https://qcs.rigetti.com/qpus) and [here](https://pyquil-docs.rigetti.com/en/stable/compiler.html)).

Incidentally, since It turns out that we cannot alter the global phase of single-qubit operations, this PR removes `global_phase_circuit` and corresponding flags from other circuits that used it.