### PR TITLE
Add tests for verbatim circuits on Lucy device

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,3 +9,13 @@ def pytest_addoption(parser):
             "Note that to run these tests you need to have AWS CLI configured."
         ),
     )
+    parser.addoption(
+        "--lucy",
+        action="store_true",
+        dest="lucy",
+        default=False,
+        help=(
+            "Enable validation tests on actual Lucy devices. "
+            "Note that to run these tests you need to have AWS CLI configured."
+        ),
+    )

--- a/tests/test_fourier_lucy.py
+++ b/tests/test_fourier_lucy.py
@@ -1,0 +1,40 @@
+import pytest
+from braket.aws import AwsDevice
+from braket.circuits import Circuit
+
+from qbench.fourier import FourierCircuits
+
+
+def _assert_can_be_run_in_verbatim_mode(device, circuit):
+    verbatim_circuit = Circuit().add_verbatim_box(circuit)
+    # Shots = 10 is the minimum number.
+    resp = device.run(verbatim_circuit, shots=10)
+    assert resp.result()
+
+
+@pytest.fixture()
+def lucy():
+    return AwsDevice("arn:aws:braket:eu-west-2::device/qpu/oqc/Lucy")
+
+
+@pytest.fixture()
+def circuits():
+    # We only use one value of phi that is not a characteristic multiple of pi/2
+    # It should be enough to verify that circuits can be run, while not incurring
+    # too big costs when tests are run.
+    return FourierCircuits(phi=0.1, gateset="lucy")
+
+
+@pytest.mark.skipif("not config.getoption('lucy')")
+class TestLucyDeviceCanRunDecomposedCircuitsInVerbatimMode:
+    def test_black_box_can_be_run(self, lucy, circuits):
+        _assert_can_be_run_in_verbatim_mode(lucy, circuits.unitary_to_discriminate(0))
+
+    def test_v0_dag_can_be_run(self, lucy, circuits):
+        _assert_can_be_run_in_verbatim_mode(lucy, circuits.v0_dag(0))
+
+    def test_v1_dag_can_be_run(self, lucy, circuits):
+        _assert_can_be_run_in_verbatim_mode(lucy, circuits.v1_dag(0))
+
+    def test_v0_v1_direct_sum_dag_can_be_run(self, lucy, circuits):
+        _assert_can_be_run_in_verbatim_mode(lucy, circuits.controlled_v0_v1_dag(0, 1))


### PR DESCRIPTION
This PR introduces tests verifying that our decomposed circuits can be run in verbatim mode on the Lucy device.
The whole logic is almost the same as with the analogous tests for Rigetti, except the command line switch is `--lucy`. We also had to disable qubit rewiring in order for the tests to run, since Lucy does not support `disable_qubit_rewiring` flag. At this point, I am not sure if one can control which qubits are used when using Lucy device.

I run the tests locally and all of them passed.

The cost of running tests with `--lucy` *only* is still below $1.50. Be mindful that running tests with both `--lucy` and `--rigetti` switches incurs both costs.